### PR TITLE
feat: implement reusable page header, centralize gradient theming, an…

### DIFF
--- a/app/apps/[id]/page.tsx
+++ b/app/apps/[id]/page.tsx
@@ -25,7 +25,15 @@ export default async function AppDetail({ params }: Props) {
   const app = await getApplicationById(Number(id));
 
   if (!app) {
-    return <div>Application not found</div>;
+    return (
+      <div className="min-h-screen bg-page-gradient flex items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-red-600 dark:text-red-400">
+            Application not found
+          </h1>
+        </div>
+      </div>
+    );
   }
 
   const thumbnailImageRetrieved = app?.thumbnail_image
@@ -37,36 +45,75 @@ export default async function AppDetail({ params }: Props) {
     : null;
 
   return (
-    <div className="p-6 mt-20">
-      <h1>App: {id}</h1>
-      <p>This will show details for the app &apos;{id}&apos; on life.au</p>
-      {app && (
-        <div>
-          <h2>application Name : {app.name}</h2>
-          <p>application Short Description :{app.short_description}</p>
-          <p>application Long Description : {app.long_description}</p>
-          <p>Advisor: {app.advisor}</p>
-          <p>Developer 1: {app.developer_1}</p>
-          {app.developer_2 && <p>Developer 2: {app.developer_2}</p>}
-          {app.developer_3 && <p>Developer 3: {app.developer_3}</p>}
-          <p>Category ID: {app.category}</p>
-          {category && <p>Category Name: {category.name}</p>}
-          <p>Thumbnail Image ID: {app.thumbnail_image}</p>
-          {thumbnailImageRetrieved?.source_url ? (
-            <Image
-              src={thumbnailImageRetrieved.source_url}
-              alt={app.name || "App thumbnail"}
-              width={400}
-              height={200}
-              style={{ objectFit: "cover" }}
-            />
-          ) : (
-            <div>No image available</div>
-          )}
-          <hr />
-          <p>Application ID: {app.id}</p>
-        </div>
-      )}
+    <div className="min-h-screen bg-page-gradient text-gray-900 dark:text-gray-100">
+      <main className="mx-auto max-w-4xl px-6 py-24">
+        <h1 className="text-3xl font-bold mb-4">App: {id}</h1>
+        <p className="text-lg mb-6">
+          This will show details for the app &apos;{id}&apos; on life.au
+        </p>
+        {app && (
+          <div className="space-y-4">
+            <h2 className="text-2xl font-semibold">
+              Application Name: {app.name}
+            </h2>
+            <p>
+              <strong>Short Description:</strong> {app.short_description}
+            </p>
+            <p>
+              <strong>Long Description:</strong> {app.long_description}
+            </p>
+            <p>
+              <strong>Advisor:</strong> {app.advisor}
+            </p>
+            <p>
+              <strong>Developer 1:</strong> {app.developer_1}
+            </p>
+            {app.developer_2 && (
+              <p>
+                <strong>Developer 2:</strong> {app.developer_2}
+              </p>
+            )}
+            {app.developer_3 && (
+              <p>
+                <strong>Developer 3:</strong> {app.developer_3}
+              </p>
+            )}
+            <p>
+              <strong>Category ID:</strong> {app.category}
+            </p>
+            {category && (
+              <p>
+                <strong>Category Name:</strong> {category.name}
+              </p>
+            )}
+            <p>
+              <strong>Thumbnail Image ID:</strong> {app.thumbnail_image}
+            </p>
+
+            <div className="my-6">
+              {thumbnailImageRetrieved?.source_url ? (
+                <Image
+                  src={thumbnailImageRetrieved.source_url}
+                  alt={app.name || "App thumbnail"}
+                  width={400}
+                  height={200}
+                  style={{ objectFit: "cover" }}
+                  className="rounded-lg shadow-md"
+                />
+              ) : (
+                <div className="bg-gray-200 dark:bg-gray-700 p-4 rounded-lg">
+                  No image available
+                </div>
+              )}
+            </div>
+
+            <hr className="border-gray-300 dark:border-gray-600 my-6" />
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              <strong>Application ID:</strong> {app.id}
+            </p>
+          </div>
+        )}
+      </main>
     </div>
   );
 }

--- a/app/apps/page.tsx
+++ b/app/apps/page.tsx
@@ -1,22 +1,24 @@
 import { getAllApplications } from "@/lib/wordpress";
+import PageHeader from "@/components/common/pageHeader";
+
 export default async function Apps() {
   const apps = await getAllApplications();
   return (
-    <div className="p-6 mt-20">
-      <h1>Apps Page</h1>
-      <p>This will show the app on life.au</p>
-      <hr />
-      <ul>
+    <div className="min-h-screen bg-page-gradient">
+      <PageHeader title="Apps" description="Explore our Apps!" />
+      {/* to be implemented later */}
+      <div>
         {apps.map((app) => (
-          <li key={app.id || app.name}>
+          <div key={app.id || app.name}>
             <h2>{app.name}</h2>
             <p>{app.short_description}</p>
             <p>Category: {app.category}</p>
-            <p>FeaturedMedia : {app.thumbnail_image}</p>
-            <hr />
-          </li>
+            {app.thumbnail_image && (
+              <p>Featured Media: {app.thumbnail_image}</p>
+            )}
+          </div>
         ))}
-      </ul>
+      </div>
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -33,6 +33,15 @@
     --ring: 0 0% 3.9%;
 
     --radius: 0.5rem;
+
+    /* Centralized gradient variables - exact match to your current colors */
+    --gradient-from: rgb(219 234 254 / 0.8); /* blue-100/80 */
+    --gradient-via: rgb(249 250 251); /* gray-50 */
+    --gradient-to: rgb(254 226 226 / 0.8); /* red-100/80 */
+    
+    --header-gradient-from: rgb(30 58 138 / 0.8); /* blue-900/80 */
+    --header-gradient-via: rgb(30 64 175 / 0.7); /* blue-800/70 */
+    --header-gradient-to: rgb(153 27 27 / 0.8); /* red-900/80 */
   }
 
   .dark {
@@ -63,6 +72,15 @@
     --border: 0 0% 14.9%;
     --input: 0 0% 14.9%;
     --ring: 0 0% 83.1%;
+
+    /* Dark mode gradient variables - exact match to your current colors */
+    --gradient-from: rgb(23 37 84); /* blue-950 */
+    --gradient-via: rgb(17 24 39); /* gray-900 */
+    --gradient-to: rgb(69 10 10); /* red-950 */
+    
+    --header-gradient-from: rgb(23 37 84 / 0.9); /* blue-950/90 */
+    --header-gradient-via: rgb(30 58 138 / 0.8); /* blue-900/80 */
+    --header-gradient-to: rgb(69 10 10 / 0.9); /* red-950/90 */
   }
 }
 
@@ -94,5 +112,16 @@
     /* IE and Edge */
     scrollbar-width: none;
     /* Firefox */
+  }
+
+  /* Centralized gradient utility classes */
+  .bg-page-gradient {
+    background: linear-gradient(to bottom right, var(--gradient-from), var(--gradient-via), var(--gradient-to));
+    transition: all 300ms;
+  }
+
+  .bg-header-gradient {
+    background: linear-gradient(to bottom right, var(--header-gradient-from), var(--header-gradient-via), var(--header-gradient-to));
+    backdrop-filter: blur(4px);
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 
 import { ReactNode } from "react";
 import Header from "@/components/common/header";
+import Footer from "@/components/common/footer";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
@@ -18,6 +19,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           >
             <Header />
             {children}
+            <Footer />
           </ThemeProvider>
         </body>
       </html>

--- a/app/news/[id]/page.tsx
+++ b/app/news/[id]/page.tsx
@@ -30,7 +30,17 @@ export default async function NewsDetail({ params }: Props) {
   const id = (await params).id;
 
   const news = await getNewsById(Number(id));
-  if (!news) return <div className="p-6">News not found</div>;
+  if (!news) {
+    return (
+      <div className="min-h-screen bg-page-gradient flex items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-red-600 dark:text-red-400">
+            News not found
+          </h1>
+        </div>
+      </div>
+    );
+  }
 
   const [thumb, category] = await Promise.all([
     news.thumbnail_image ? getFeaturedMediaById(news.thumbnail_image) : null,
@@ -43,15 +53,14 @@ export default async function NewsDetail({ params }: Props) {
     news.short_description || "— No short description provided —";
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-100/80 via-gray-50 to-red-100/80 dark:from-blue-950 dark:via-gray-900 dark:to-red-950 transition-colors duration-300 text-zinc-900 dark:text-zinc-50">
-      <header className="relative mt-auto border-t bg-gradient-to-br from-blue-900/80 via-blue-800/70 to-red-900/80 dark:from-blue-950/90 dark:via-blue-900/80 dark:to-red-950/90 backdrop-blur-sm">
-        <div className="absolute inset-0 bg-black/20 dark:bg-black/40"></div>
+    <div className="min-h-screen bg-page-gradient text-zinc-900 dark:text-zinc-50">
+      {/* <header className="relative mt-auto border-t bg-header-gradient">
         <div className="mx-auto max-w-5xl px-6 h-48 flex items-center justify-center">
           <h1 className="relative text-center text-2xl md:text-3xl font-bold pt-10 text-white">
             {title}
           </h1>
         </div>
-      </header>
+      </header> */}
 
       <main className="mx-auto max-w-3xl px-6 pb-10 pt-10">
         <div className="flex justify-center">
@@ -93,8 +102,7 @@ export default async function NewsDetail({ params }: Props) {
         </section>
       </main>
 
-      <footer className="relative mt-auto border-t bg-gradient-to-br from-blue-900/80 via-blue-800/70 to-red-900/80 dark:from-blue-950/90 dark:via-blue-900/80 dark:to-red-950/90 backdrop-blur-sm">
-        <div className="absolute inset-0 bg-black/20 dark:bg-black/40"></div>
+      <footer className="relative mt-auto border-t ">
         <div className="relative mx-auto max-w-5xl px-6 py-8 text-center">
           <div className="text-xl font-semibold">
             <span className="text-2xl font-bold text-white">Life.</span>

--- a/app/news/[id]/page.tsx
+++ b/app/news/[id]/page.tsx
@@ -54,13 +54,13 @@ export default async function NewsDetail({ params }: Props) {
 
   return (
     <div className="min-h-screen bg-page-gradient text-zinc-900 dark:text-zinc-50">
-      {/* <header className="relative mt-auto border-t bg-header-gradient">
+      <header className="relative mt-auto border-t bg-header-gradient">
         <div className="mx-auto max-w-5xl px-6 h-48 flex items-center justify-center">
           <h1 className="relative text-center text-2xl md:text-3xl font-bold pt-10 text-white">
             {title}
           </h1>
         </div>
-      </header> */}
+      </header>
 
       <main className="mx-auto max-w-3xl px-6 pb-10 pt-10">
         <div className="flex justify-center">
@@ -101,16 +101,6 @@ export default async function NewsDetail({ params }: Props) {
           </span>
         </section>
       </main>
-
-      <footer className="relative mt-auto border-t ">
-        <div className="relative mx-auto max-w-5xl px-6 py-8 text-center">
-          <div className="text-xl font-semibold">
-            <span className="text-2xl font-bold text-white">Life.</span>
-            <span className="text-red-300">au</span>
-          </div>
-          <p className="mt-1 text-[11px] text-white/70">by d*code 2025</p>
-        </div>
-      </footer>
     </div>
   );
 }

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -1,23 +1,28 @@
 import { getAllNews } from "@/lib/wordpress";
+import PageHeader from "@/components/common/pageHeader";
 
 export default async function News() {
   const news = await getAllNews();
   return (
-    <div className="p-6 mt-20">
-      <h1>Activities Page</h1>
-      <p>This will show the activities on life.au</p>
-
-      <hr />
-      {news.map((activity) => (
-        <div key={activity.id}>
-          <h2>{activity.title}</h2>
-          <p>{activity.short_description}</p>
-          <p>{activity.date}</p>
-          <p>category id: {activity?.category}</p>
-          <p>thumbnail image id: {activity?.thumbnail_image}</p>
-          <hr />
-        </div>
-      ))}
+    <div className="min-h-screen bg-page-gradient">
+      <PageHeader
+        title="Student Activities"
+        description="Explore our Activities!"
+      />
+      {/* to be implemented later */}
+      <div>
+        {news.map((activity) => (
+          <div key={activity.id}>
+            <h2>{activity.title}</h2>
+            <p>{activity.short_description}</p>
+            <p>Date: {activity.date}</p>
+            {activity.category && <p>Category ID: {activity.category}</p>}
+            {activity.thumbnail_image && (
+              <p>Thumbnail ID: {activity.thumbnail_image}</p>
+            )}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,14 +2,10 @@ import HeroSection from "@/components/home/hero/heroSection";
 import FeatureProjects from "@/components/home/projects/featureProjects";
 import FeatureNews from "@/components/home/news/featureNews";
 import Footer from "@/components/common/footer";
-import Header from "@/components/common/header";
 
 export default function HomePage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-100/80 via-gray-50 to-red-100/80 dark:from-blue-950 dark:via-gray-900 dark:to-red-950 transition-colors duration-300">
-      {/* Header */}
-      <Header />
-
+    <div className="min-h-screen bg-page-gradient">
       {/* Hero Section */}
       <HeroSection />
 
@@ -18,9 +14,6 @@ export default function HomePage() {
 
       {/* News Section */}
       <FeatureNews />
-
-      {/* Footer */}
-      <Footer />
     </div>
   );
 }

--- a/components/common/pageHeader.tsx
+++ b/components/common/pageHeader.tsx
@@ -1,0 +1,22 @@
+interface PageHeaderProps {
+  title: string;
+  description: string;
+}
+
+export default function PageHeader({ title, description }: PageHeaderProps) {
+  return (
+    <section className="relative pt-24 pb-16 px-4 sm:px-6 lg:px-8 overflow-hidden min-h-[300px] flex items-center justify-center">
+      <div className="absolute inset-0 bg-header-gradient">
+        <div className="absolute inset-0 bg-black/20 dark:bg-black/30"></div>
+      </div>
+      <div className="relative z-10 max-w-4xl mx-auto text-center">
+        <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-white mb-6 drop-shadow-lg">
+          {title}
+        </h1>
+        <p className="text-xl sm:text-2xl text-white/90 drop-shadow-md max-w-2xl mx-auto">
+          {description}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/components/home/hero/heroSection.tsx
+++ b/components/home/hero/heroSection.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 export default function HeroSection() {
   return (
     <section className="relative pt-24 pb-12 px-4 sm:px-6 lg:px-8 overflow-hidden min-h-[400px] flex items-center justify-center">
-      <div className="absolute inset-0 bg-gradient-to-br from-blue-900/80 via-blue-800/70 to-red-900/80 dark:from-blue-950/90 dark:via-blue-900/80 dark:to-red-950/90 backdrop-blur-sm">
+      <div className="absolute inset-0 bg-header-gradient">
         <div className="absolute inset-0 bg-black/20 dark:bg-black/30"></div>
       </div>
       <div className="relative z-10 max-w-4xl mx-auto text-center">


### PR DESCRIPTION
…d fix layout issues

- Add reusable PageHeader component for apps and news pages
- Add Footer component to root layout for consistent site structure
- Centralize gradient backgrounds with CSS variables in globals.css
- Create bg-page-gradient and bg-header-gradient utility classes
- Fix app detail page padding and layout structure
- Update all pages to use centralized gradient system